### PR TITLE
Fixed flaw in intent changes in skeleton minionisation

### DIFF
--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -421,14 +421,15 @@
 	can_do_sex = FALSE //where my bonger go
 
 	// Undead have infinite stamina; they should not be using swift intent under any circumstances.
-	target.possible_rmb_intents = list(/datum/rmb_intent/feint,\
+	possible_rmb_intents = list(/datum/rmb_intent/feint,\
 		/datum/rmb_intent/aimed,\
 		/datum/rmb_intent/strong,\
 		/datum/rmb_intent/riposte,\
 		/datum/rmb_intent/weak)
 
-	if (istype(target.rmb_intent, /datum/rmb_intent/swift))
-		target.swap_rmb_intent(null, 1)
+	if (istype(rmb_intent, /datum/rmb_intent/swift))
+		swap_rmb_intent(null, 1)
+
 
 	ADD_TRAIT(src, TRAIT_CRITICAL_WEAKNESS, TRAIT_GENERIC) //Why wasn't this a thing from the start
 	ADD_TRAIT(src, TRAIT_NOMOOD, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR fixes an issue - which I unfortunately introduced - which causes necromancer- and lich-reanimated skeletons not to initialise correctly. I'm not quite sure how I didn't notice when testing - probably a last-minute change out of uncertainty that backfired.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simply a fix for a bug I introduced, restoring intended skeleton functionality.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


## Proof of Testing (Required)
Me and a skeleton I reanimated showing all traits correctly loaded.
![image](https://github.com/user-attachments/assets/6f9dd66e-8f6a-47ed-a631-67d059a6d1d1)

<!-- Show proof of testing, screenshots or recordings for features, proof of compile for backend changes -->
